### PR TITLE
Add hylint: Hy linter with style checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## 🦑 Beautifhy
 
-*A [Hy](https://hylang.org) beautifier / code formatter / pretty-printer.*
+*A [Hy](https://hylang.org) beautifier / code formatter / pretty-printer / linter.*
 
 Probably compatible with Hy 1.0.0 and later.
 
@@ -86,6 +86,50 @@ To convert python code to Hy (using [py2hy](https://github.com/hylang/py2hy)), a
 $ pip3 install py2hy
 $ python3 -m py2hy some_code.py | beautifhy - | hylight -
 ```
+
+### Usage: linter
+
+`hylint` checks Hy source for syntax errors and common issues.
+
+```bash
+$ hylint myfile.hy
+```
+
+With `--style` / `-s`, also runs opinionated style checks (camelCase names,
+missing docstrings, earmuff variables):
+
+```bash
+$ hylint --style myfile.hy
+```
+
+With `--error-only` / `-e`, only errors are shown (suppresses warnings and info):
+
+```bash
+$ hylint --error-only myfile.hy
+```
+
+Reads from stdin with `-`:
+```bash
+$ cat myfile.hy | hylint -
+```
+
+Exit code is 1 if any errors are found, 0 otherwise. Suitable for CI.
+
+**Lint rules (always on):**
+- `(defn f (x) ...)` — use `[]` for parameter lists, not `()`
+- `(defn f [...] (do ...))` — remove redundant `do`
+- `(fn [...] (do ...))` — remove redundant `do`
+- `(when cond (do ...))` — remove redundant `do`
+- `(if cond (do ...))` — use `(when cond ...)`
+- `(do expr)` — redundant single-expression `do`
+- `(+ x 0)`, `(* x 1)` — identity arithmetic
+- `(+ x 1)` → `(inc x)`, `(- x 1)` → `(dec x)` (from hyrule)
+
+**Style rules (`--style`):**
+- camelCase function names — use kebab-case
+- Missing docstrings on `defn`/`defmacro`
+- Trailing commas in parameter lists
+- Earmuff variables (`*var*`) — use UPPER_SNAKE or kebab-case
 
 ### Acknowledgements
 

--- a/beautifhy/__init__.py
+++ b/beautifhy/__init__.py
@@ -138,3 +138,70 @@ def __cli_hylight_files():
         print()
         print(highlight.highlight(code, lexer, formatter))
         print()
+
+
+def __cli_lint_files():
+    """Lint Hy files from the shell."""
+    import hy
+    from beautifhy.lint import lint, report_issues
+    from beautifhy.style import lint_style, lint_style_forms
+    from beautifhy.core import slurp
+
+    parser = argparse.ArgumentParser(
+        description="Lint Hy files for syntax errors and common issues.",
+        prog="hylint"
+    )
+    parser.add_argument(
+        "files",
+        nargs="*",
+        help="Hy files to lint (use '-' for stdin)"
+    )
+    parser.add_argument(
+        "--style", "-s",
+        action="store_true",
+        help="also run opinionated style checks (camelCase, docstrings, earmuffs)"
+    )
+    parser.add_argument(
+        "--error-only", "-e",
+        action="store_true",
+        help="only show errors (not warnings or info)"
+    )
+    parser.add_argument(
+        "--version", "-v",
+        action="version",
+        version=f"%(prog)s {__version__}"
+    )
+
+    args = parser.parse_args()
+
+    def check(code, filename):
+        issues = lint(code)
+        if args.style:
+            issues += lint_style(code)
+        if args.error_only:
+            issues = [i for i in issues if i.get("severity") == "error"]
+        # Sort by line number for readable output
+        issues.sort(key=lambda i: (i.get("line", 0), i.get("column", 0)))
+        return report_issues(issues, filename=filename)
+
+    total_errors = 0
+    total_warnings = 0
+
+    if not args.files:
+        result = check(sys.stdin.read(), "<stdin>")
+        total_errors += result["errors"]
+        total_warnings += result["warnings"]
+    else:
+        for fname in args.files:
+            if fname == "-":
+                result = check(sys.stdin.read(), "<stdin>")
+            elif fname.endswith(".hy"):
+                result = check(slurp(fname), fname)
+            else:
+                print(f"hylint: unrecognised file extension: {fname}", file=sys.stderr)
+                sys.exit(2)
+            total_errors += result["errors"]
+            total_warnings += result["warnings"]
+
+    if total_errors > 0:
+        sys.exit(1)

--- a/beautifhy/core.hy
+++ b/beautifhy/core.hy
@@ -1,3 +1,8 @@
+"
+Utility functions and macros.
+Stolen from hyjinx, duplicated here to avoid a fat import.
+"
+
 (import toolz [first second last])
 
 
@@ -47,4 +52,29 @@
 (defmacro rest [xs]
   "A slice of all but the first element of a sequence."
   `(cut ~xs 1 None))
+
+
+;; * Lint/style shared utilities
+;; -----------------------------------------
+
+(defn issue [msg severity line col]
+  "Create a lint/style issue dict."
+  {"message" msg "severity" severity "line" line "column" col})
+
+(defn defn-layout [form]
+  "Return [name-idx params-idx] for a defn/fn form.
+  Accounts for optional :async keyword and decorator list.
+  (defn name [params] ...)                 → [1 2]
+  (defn [decorator] name [params] ...)     → [2 3]
+  (defn :async name [params] ...)          → [2 3]
+  (defn :async [decorator] name [params])  → [3 4]"
+  (import hy.models [Keyword List])
+  (let [offset 1]
+    (when (and (>= (len form) (+ offset 1))
+               (isinstance (get form offset) Keyword))
+      (+= offset 1))
+    (when (and (>= (len form) (+ offset 1))
+               (isinstance (get form offset) List))
+      (+= offset 1))
+    [offset (+ offset 1)]))
 

--- a/beautifhy/lint.hy
+++ b/beautifhy/lint.hy
@@ -1,0 +1,228 @@
+"
+beautifhy.lint - Hy linter for syntax errors and common improvement suggestions.
+
+Rules:
+- defn/fn with () parameter list instead of []
+- redundant (do ...) in defn/fn/when/unless/if bodies
+- (if cond (do ...)) should be (when cond ...)
+- identity arithmetic: (+ x 0), (* x 1)
+- (+ x 1) / (- x 1) should use inc/dec from hyrule
+- old-style import syntax: (import [module [sym]])
+"
+
+(require hyrule [-> ->>])
+(require beautifhy.core [defmethod])
+
+(import hy.models [Expression List Integer String Symbol Object])
+(import hy.reader [read-many])
+(import hy.errors [HySyntaxError HyCompileError])
+(import hy.reader.exceptions [LexException])
+(import beautifhy.core [issue defn-layout])
+
+;; * Severity levels
+(setv ERROR "error")
+(setv WARNING "warning")
+(setv INFO "info")
+
+;; * Constants for dispatch and comparison
+(setv DEFN   (Symbol "defn"))
+(setv FN     (Symbol "fn"))
+(setv IF     (Symbol "if"))
+(setv WHEN   (Symbol "when"))
+(setv UNLESS (Symbol "unless"))
+(setv DO     (Symbol "do"))
+(setv PLUS   (Symbol "+"))
+(setv MINUS  (Symbol "-"))
+(setv STAR   (Symbol "*"))
+(setv IMPORT     (Symbol "import"))
+(setv QUASIQUOTE (Symbol "quasiquote"))
+(setv ZERO (Integer 0))
+(setv ONE  (Integer 1))
+
+;; * Helpers
+(defn has-do-body? [form param-count]
+  "True if form has exactly one body expression which is a (do ...) form."
+  (and (= (len form) (+ param-count 2))
+       (let [body (get form (+ param-count 1))]
+         (and (isinstance body Expression)
+              (> (len body) 0)
+              (= (get body 0) DO)))))
+
+;; * Main lint dispatcher
+;;
+;; Note: Symbol inherits from both Object and str. A [#^ str] overload would
+;; be ambiguous with [#^ Object] for Symbols. The source-string entry point is
+;; therefore a plain function; defmethod handles model types only.
+
+(defn lint [source]
+  "Parse and lint Hy source string."
+  (try
+    (lint-forms (list (read-many source)))
+    (except [e LexException]
+      [(issue f"Lex error: {e.msg}" ERROR (or e.lineno 1) (or e.offset 0))])
+    (except [e HySyntaxError]
+      [(issue f"Syntax error: {e.msg}" ERROR (or e.lineno 1) (or e.colno 0))])
+    (except [e HyCompileError]
+      [(issue f"Compile error: {e}" ERROR 1 0)])
+    (except [e Exception]
+      [(issue f"Parse error: {e}" ERROR 1 0)])))
+
+(defn lint-forms [forms]
+  "Lint a list of top-level forms."
+  (let [issues []]
+    (for [f forms]
+      (.extend issues (lint-form f)))
+    issues))
+
+(defmethod lint-form [#^ Expression form]
+  "Lint a single expression and recurse into subforms."
+  (let [issues []
+        line   (or form.start-line 1)
+        col    (or form.start-column 0)]
+    (when (and form (> (len form) 0))
+      (let [head (get form 0)]
+        (cond
+          ;; Don't lint inside quasiquote templates — they contain unquote
+          ;; expressions that look like code but are data for macro expansion.
+          (= head QUASIQUOTE)                 None
+          (= head DEFN)                       (.extend issues (lint-defn form line col))
+          (= head FN)                         (.extend issues (lint-fn form line col))
+          (= head IF)                         (.extend issues (lint-if form line col))
+          (in head [WHEN UNLESS])             (.extend issues (lint-when form line col))
+          (= head DO)                         (.extend issues (lint-do form line col))
+          (in head [PLUS MINUS STAR])         (.extend issues (lint-arithmetic form line col))
+          (= head IMPORT)                     (.extend issues (lint-import form line col)))
+        ;; Don't recurse into quasiquote — its children are template data, not code.
+        (when (!= head QUASIQUOTE)
+          (for [sub form]
+            (.extend issues (lint-form sub))))))
+    issues))
+
+(defmethod lint-form [#^ Object form]
+  "Atoms have no issues."
+  [])
+
+;; * Rules
+(defn lint-defn [form line col]
+  "Lint defn: check param list brackets, redundant do body.
+  Handles both plain and decorated defn forms."
+  (let [issues []
+        #(name-idx params-idx) (defn-layout form)]
+    (when (>= (len form) (+ params-idx 1))
+      (let [params (get form params-idx)]
+        (cond
+          (isinstance params Expression)
+            (.append issues (issue "Use [] for parameter lists, not ()" ERROR line col))
+          (and (isinstance params List) (has-do-body? form params-idx))
+            (.append issues (issue "(defn [...] (do ...)) — remove redundant do" INFO line col)))))
+    issues))
+
+(defn lint-fn [form line col]
+  "Lint fn: check param list brackets, redundant do body."
+  (let [issues []]
+    (when (>= (len form) 2)
+      (let [params (get form 1)]
+        (cond
+          (isinstance params Expression)
+            (.append issues (issue "Use [] for parameter lists, not ()" ERROR line col))
+          (and (isinstance params List) (has-do-body? form 1))
+            (.append issues (issue "(fn [...] (do ...)) — remove redundant do" INFO line col)))))
+    issues))
+
+(defn lint-if [form line col]
+  "Lint if: (if cond (do ...)) should be (when cond ...).
+  Also checks for redundant do in either branch of a full if/else."
+  (let [issues []]
+    ;; (if cond (do ...)) with no else → use (when cond ...)
+    (when (= (len form) 3)
+      (let [consequent (get form 2)]
+        (when (and (isinstance consequent Expression)
+                   (> (len consequent) 0)
+                   (= (get consequent 0) DO))
+          (.append issues (issue "(if cond (do ...)) — use (when cond ...)" INFO line col)))))
+    ;; (if cond then-expr (do ...)) → redundant do in else
+    (when (= (len form) 4)
+      (let [alternative (get form 3)]
+        (when (and (isinstance alternative Expression)
+                   (> (len alternative) 0)
+                   (= (get alternative 0) DO))
+          (.append issues (issue "(if cond x (do ...)) — remove redundant do in else branch" INFO line col)))))
+    issues))
+
+(defn lint-when [form line col]
+  "Lint when/unless: redundant do body."
+  (let [issues []]
+    (when (has-do-body? form 1)
+      (.append issues (issue "(when/unless cond (do ...)) — remove redundant do" INFO line col)))
+    issues))
+
+(defn lint-do [form line col]
+  "Lint bare single-expression do."
+  (let [issues []]
+    (when (= (len form) 2)
+      (.append issues (issue "(do expr) is redundant — use expr directly" INFO line col)))
+    issues))
+
+(defn lint-arithmetic [form line col]
+  "Lint trivial arithmetic: identity operations, inc/dec suggestions."
+  (let [issues []
+        head   (get form 0)
+        n      (len form)]
+    (when (= n 3)
+      (let [a (get form 1)
+            b (get form 2)]
+        (cond
+          ;; (+ x 0) or (+ 0 x)
+          (and (= head PLUS) (or (= a ZERO) (= b ZERO)))
+            (.append issues (issue "(+ x 0) — adding zero is redundant" INFO line col))
+          ;; (* x 1) or (* 1 x)
+          (and (= head STAR) (or (= a ONE) (= b ONE)))
+            (.append issues (issue "(* x 1) — multiplying by one is redundant" INFO line col))
+          ;; (+ x 1) or (+ 1 x) → (inc x)
+          (and (= head PLUS) (or (= a ONE) (= b ONE)))
+            (.append issues (issue "(+ x 1) — use (inc x) from hyrule" INFO line col))
+          ;; (- x 1) → (dec x)
+          (and (= head MINUS) (= b ONE))
+            (.append issues (issue "(- x 1) — use (dec x) from hyrule" INFO line col)))))
+    issues))
+
+(defn lint-import [form line col]
+  "Lint old-style import syntax.
+
+  (import [module [sym1 sym2]]) was removed in Hy 1.0 and will fail to
+  compile. Use (import module [sym1 sym2]) instead."
+  (let [issues []]
+    (when (and (>= (len form) 2) (isinstance (get form 1) List))
+      (.append issues (issue "Old-style import — use (import module [sym1 sym2])" ERROR line col)))
+    issues))
+
+;; * File entry points
+(defn lint-file [fname]
+  "Lint a single Hy file, return list of issues."
+  (import beautifhy.core [slurp])
+  (lint-forms (list (read-many (slurp fname)))))
+
+(defn lint-files [fnames]
+  "Lint multiple Hy files."
+  (let [issues []]
+    (for [f fnames]
+      (.extend issues (lint-file f)))
+    issues))
+
+;; * Reporting
+(defn report-issues [issues [filename "<input>"]]
+  "Print issues to stderr and return summary dict."
+  (let [error-count   0
+        warning-count 0]
+    (for [i issues]
+      (let [sev  (:severity i ERROR)
+            line (:line i 0)
+            col  (:column i 0)
+            msg  (:message i "")]
+        (print f"{filename}:{line}:{col}: {sev}: {msg}" :file hy.I.sys.stderr)
+        (cond
+          (= sev ERROR)   (+= error-count 1)
+          (= sev WARNING) (+= warning-count 1))))
+    (when issues
+      (print f"\n{filename}: {error-count} error(s), {warning-count} warning(s)" :file hy.I.sys.stderr))
+    {"errors" error-count "warnings" warning-count "total" (len issues)}))

--- a/beautifhy/style.hy
+++ b/beautifhy/style.hy
@@ -1,0 +1,133 @@
+"
+beautifhy.style - Opinionated style linting for Hy
+
+These rules are conventions, not correctness issues. Enable with --style flag.
+
+Opinionated choices:
+- camelCase discouraged: Hy uses kebab-case by convention
+- Earmuffs (*var*) discouraged: unidiomatic, gets heavily mangled
+- Missing docstrings: defn/defmacro should describe their purpose
+- Trailing commas in params: Hy doesn't use commas; this is a Python habit
+"
+
+(require beautifhy.core [defmethod])
+
+(import hy.models [Expression List Symbol Object String])
+(import hy.reader [read-many])
+(import beautifhy.core [issue defn-layout])
+
+;; * Severity levels (re-exported for CLI use)
+(setv WARNING "warning")
+(setv INFO "info")
+
+;; * Dispatcher
+;;
+;; Note: Symbol inherits from both str and Object, so we cannot use a str
+;; overload in the multimethod — it creates an ambiguous dispatch for Symbols.
+;; The source-string entry point is therefore a plain function, not a defmethod.
+
+(defn lint-style [source]
+  "Style-check Hy source code string.
+  Returns [] on parse errors — correctness errors are lint.hy's job."
+  (try
+    (lint-style-forms (list (read-many source)))
+    (except [e Exception]
+      [])))
+
+(defn lint-style-forms [forms]
+  "Style-check a list of top-level forms."
+  (let [issues []]
+    (for [f forms]
+      (.extend issues (lint-style-form f)))
+    issues))
+
+(defmethod lint-style-form [#^ Expression form]
+  "Style-check a single expression."
+  (let [issues []
+        line   (or form.start-line 1)
+        col    (or form.start-column 0)]
+    (when (and form (> (len form) 0))
+      (let [head (get form 0)]
+        (when (isinstance head Symbol)
+          (cond
+            ;; Skip quasiquote bodies — unquote expressions look like code but are data.
+            (= head (Symbol "quasiquote"))
+              None
+            (in head [(Symbol "defn") (Symbol "defun") (Symbol "fn") (Symbol "defmacro")])
+              (.extend issues (style-defn-like form line col))
+            (= head (Symbol "setv"))
+              (.extend issues (style-setv form line col))))
+        ;; Don't recurse into quasiquote — its children are template data, not code.
+        (when (!= head (Symbol "quasiquote"))
+          (for [sub form]
+            (.extend issues (lint-style-form sub))))))
+    issues))
+
+(defmethod lint-style-form [#^ Object form]
+  "Atoms have no style issues."
+  [])
+
+;; * Rules
+
+(defn style-defn-like [form line col]
+  "Check defn/fn/defmacro for camelCase name, missing docstring, trailing commas.
+
+  Not flagging ClassNames (PascalCase is correct for classes, defined with
+  defclass not defn)."
+  (let [issues []
+        op-name (str (get form 0))
+        #(name-idx params-idx) (defn-layout form)
+        body-idx (+ params-idx 1)]
+    ;; camelCase function name: has uppercase after a lowercase letter
+    (when (and (>= (len form) (+ name-idx 1))
+               (isinstance (get form name-idx) Symbol))
+      (let [fname (str (get form name-idx))
+            chars (list fname)]
+        (for [i (range 1 (len chars))]
+          (when (and (.islower (get chars (- i 1)))
+                     (.isupper (get chars i)))
+            (.append issues (issue f"Use kebab-case, not camelCase: {fname}" WARNING line col))
+            (break)))))
+    ;; Missing docstring (defn/defmacro only, not fn)
+    (when (and (>= (len form) (+ body-idx 1))
+               (in op-name ["defn" "defun" "defmacro"]))
+      (let [fname (str (get form name-idx))
+            first-body (get form body-idx)]
+        (when (not (isinstance first-body String))
+          (.append issues (issue f"{op-name} '{fname}' has no docstring" INFO line col)))))
+    ;; Trailing commas in parameter list
+    (when (>= (len form) (+ params-idx 1))
+      (let [params (get form params-idx)]
+        (when (isinstance params List)
+          (for [p params]
+            (when (and (isinstance p Symbol)
+                       (.endswith (str p) ","))
+              (.append issues (issue f"Remove trailing comma from parameter: {p}" WARNING line col)))))))
+    issues))
+
+(defn style-setv [form line col]
+  "Check setv for earmuff variable names.
+
+  Earmuffs (*var*) are unidiomatic in Hy and mangle heavily. Use
+  UPPER_SNAKE or kebab-case for module-level names instead."
+  (let [issues []]
+    (when (>= (len form) 2)
+      (let [varname (get form 1)]
+        (when (isinstance varname Symbol)
+          (let [name (str varname)]
+            (when (and (.startswith name "*") (.endswith name "*"))
+              (.append issues (issue f"Earmuffs are unidiomatic — use UPPER_SNAKE or kebab-case: {name}" INFO line col)))))))
+    issues))
+
+;; * Entry points
+(defn lint-file-style [fname]
+  "Style-check a single Hy file, return list of issues."
+  (import beautifhy.core [slurp])
+  (lint-style-forms (list (read-many (slurp fname)))))
+
+(defn lint-files-style [fnames]
+  "Style-check multiple Hy files."
+  (let [issues []]
+    (for [f fnames]
+      (.extend issues (lint-file-style f)))
+    issues))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: Utilities"
 ]
 dependencies = [
-    "hy>=1.0.0",
+    "hy>=1.2.0",
     "hyrule>=1.0.0",
     "multimethod>=2.0",
     "pygments",
@@ -51,6 +51,7 @@ version = {attr = "beautifhy.__version__"}
 [project.scripts]
 beautifhy = "beautifhy:__cli_grind_files"
 hylight = "beautifhy:__cli_hylight_files"
+hylint = "beautifhy:__cli_lint_files"
 
 [tool.pytest.ini_options]
 python_files = ["test_*.py", "*_test.py", "test_*.hy", "*_test.hy"]

--- a/tests/native_tests/test_lint.hy
+++ b/tests/native_tests/test_lint.hy
@@ -1,0 +1,150 @@
+"
+Test cases for beautifhy.lint
+"
+
+(require hyrule [-> ->>])
+(import beautifhy.lint [lint ERROR WARNING INFO])
+(import beautifhy.core [issue])
+
+
+(defn has-message? [issues msg-substr]
+  "True if any issue contains msg-substr in its message."
+  (any (lfor i issues (in msg-substr (:message i "")))))
+
+
+(defn test-lint-defn-params-brackets []
+  "Test that (defn f (x) ...) is flagged (should be [x])."
+  (let [code "(defn foo (x y) (+ x y))"
+        issues (lint code)]
+    (assert (has-message? issues "Use [] for parameter lists"))))
+
+
+(defn test-lint-defn-correct []
+  "Test that correct (defn f [x] ...) passes."
+  (let [code "(defn foo [x y] (+ x y))"
+        issues (lint code)]
+    ;; Should not have the bracket error
+    (assert (not (has-message? issues "Use [] for parameter lists")))))
+
+
+(defn test-lint-if-with-do []
+  "Test that (if c (do ...)) suggests using when."
+  (let [code "(if condition (do something))"
+        issues (lint code)]
+    (assert (has-message? issues "use (when"))))
+
+
+(defn test-lint-defn-with-do []
+  "Test that (defn f [...] (do ...)) is flagged."
+  (let [code "(defn foo [x] (do (+ x 1)))"
+        issues (lint code)]
+    (assert (has-message? issues "redundant do"))))
+
+
+(defn test-lint-fn-with-do []
+  "Test that (fn [...] (do ...)) is flagged."
+  (let [code "(fn [x] (do (print x)))"
+        issues (lint code)]
+    (assert (has-message? issues "redundant do"))))
+
+
+(defn test-lint-when-with-do []
+  "Test that (when c (do ...)) is flagged."
+  (let [code "(when cond (do (print 1)))"
+        issues (lint code)]
+    (assert (has-message? issues "redundant do"))))
+
+
+(defn test-lint-bare-do []
+  "Test that (do x) single-expr do is flagged."
+  (let [code "(do (print 1))"
+        issues (lint code)]
+    (assert (has-message? issues "redundant"))))
+
+
+(defn test-lint-arithmetic-add-zero []
+  "Test that (+ x 0) is flagged."
+  (let [code "(+ x 0)"
+        issues (lint code)]
+    (assert (has-message? issues "adding zero"))))
+
+
+(defn test-lint-arithmetic-mul-one []
+  "Test that (* x 1) is flagged."
+  (let [code "(* x 1)"
+        issues (lint code)]
+    (assert (has-message? issues "multiplying by one"))))
+
+
+(defn test-lint-arithmetic-inc []
+  "Test that (+ x 1) suggests inc."
+  (let [code "(+ x 1)"
+        issues (lint code)]
+    (assert (has-message? issues "inc"))))
+
+
+(defn test-lint-arithmetic-dec []
+  "Test that (- x 1) suggests dec."
+  (let [code "(- x 1)"
+        issues (lint code)]
+    (assert (has-message? issues "dec"))))
+
+
+(defn test-lint-fn-params-brackets []
+  "Test that fn with () params is flagged."
+  (let [issues (lint "(fn (x) x)")]
+    (assert (has-message? issues "Use [] for parameter lists"))))
+
+
+(defn test-lint-fn-params-correct []
+  "Test that fn with [] params is clean."
+  (let [issues (lint "(fn [x] x)")]
+    (assert (not (has-message? issues "Use [] for parameter lists")))))
+
+
+(defn test-lint-if-else-do []
+  "Test that redundant do in else branch is flagged."
+  (let [issues (lint "(if cond x (do y z))")]
+    (assert (has-message? issues "redundant do in else"))))
+
+
+(defn test-lint-decorated-defn []
+  "Test that decorated defn with [] params is clean."
+  (let [issues (lint "(defn [some-decorator] foo [x] x)")]
+    (assert (not (has-message? issues "Use [] for parameter lists")))))
+
+
+(defn test-lint-async-defn []
+  "Test that :async defn with [] params is clean."
+  (let [issues (lint "(defn :async foo [x] x)")]
+    (assert (not (has-message? issues "Use [] for parameter lists")))))
+
+
+(defn test-lint-empty-expression []
+  "Test that empty expressions don't crash the linter."
+  ;; This shouldn't raise — just return no issues or parse error
+  (let [issues (lint "()")]
+    (assert (isinstance issues list))))
+
+
+(defn test-lint-old-style-import []
+  "Test that old-style (import [module [sym]]) is flagged as error."
+  (let [issues (lint "(import [os [path]])")]
+    (assert (has-message? issues "Old-style import"))))
+
+
+(defn test-issue-structure []
+  "Test that issues have the correct structure."
+  (let [i (issue "test message" ERROR 5 10)]
+    (assert (= (:message i) "test message"))
+    (assert (= (:severity i) ERROR))
+    (assert (= (:line i) 5))
+    (assert (= (:column i) 10))))
+
+
+(defn test-lint-clean-code []
+  "Test that clean code produces no issues."
+  (let [code "(defn foo [x] (- x 5))"
+        issues (lint code)]
+    ;; Should have no issues at all
+    (assert (= (len issues) 0))))

--- a/tests/native_tests/test_style.hy
+++ b/tests/native_tests/test_style.hy
@@ -1,0 +1,68 @@
+"
+Test cases for beautifhy.style
+"
+
+(import beautifhy.style [lint-style WARNING INFO])
+(import beautifhy.core [issue])
+
+
+(defn has-message? [issues substr]
+  "True if any issue contains substr in its message."
+  (any (lfor i issues (in substr (:message i "")))))
+
+
+(defn test-style-camel-case []
+  "Test that camelCase function names are flagged."
+  (let [issues (lint-style "(defn myFunc [x] \"doc\" x)")]
+    (assert (has-message? issues "kebab-case"))))
+
+
+(defn test-style-kebab-case-clean []
+  "Test that kebab-case names are not flagged."
+  (let [issues (lint-style "(defn my-func [x] \"doc\" x)")]
+    (assert (not (has-message? issues "kebab-case")))))
+
+
+(defn test-style-missing-docstring []
+  "Test that defn without docstring is flagged."
+  (let [issues (lint-style "(defn foo [x] (+ x 1))")]
+    (assert (has-message? issues "docstring"))))
+
+
+(defn test-style-has-docstring-clean []
+  "Test that defn with docstring is not flagged for docstring."
+  (let [issues (lint-style "(defn foo [x] \"Add one.\" (+ x 1))")]
+    (assert (not (has-message? issues "docstring")))))
+
+
+(defn test-style-trailing-comma []
+  "Test that trailing commas in params are flagged."
+  (let [issues (lint-style "(defn foo [x,] \"doc\" x)")]
+    (assert (has-message? issues "trailing comma"))))
+
+
+(defn test-style-earmuffs []
+  "Test that earmuff variable names are flagged."
+  (let [issues (lint-style "(setv *global* 42)")]
+    (assert (has-message? issues "Earmuffs"))))
+
+
+(defn test-style-earmuffs-clean []
+  "Test that normal variable names are not flagged."
+  (let [issues (lint-style "(setv GLOBAL 42)")]
+    (assert (not (has-message? issues "Earmuffs")))))
+
+
+(defn test-style-clean-code []
+  "Test that fully clean code produces no style issues."
+  (let [issues (lint-style "(defn good-fn [x] \"Does something.\" (- x 5))")]
+    (assert (= (len issues) 0))))
+
+
+(defn test-issue-structure []
+  "Test that style issues have the correct structure."
+  (let [i (issue "test" WARNING 3 7)]
+    (assert (= (:message i) "test"))
+    (assert (= (:severity i) WARNING))
+    (assert (= (:line i) 3))
+    (assert (= (:column i) 7))))


### PR DESCRIPTION
## Summary

Adds `hylint`, a Hy linter with correctness rules and optional style checks.

### Lint rules (always on)
- `defn`/`fn` with `()` params instead of `[]`
- Redundant `(do ...)` in `defn`/`fn`/`when`/`unless`/`if` bodies
- `(if cond (do ...))` should be `(when cond ...)`
- Redundant `do` in if/else branch
- Identity arithmetic: `(+ x 0)`, `(* x 1)`
- `(+ x 1)`/`(- x 1)` should use `inc`/`dec` from hyrule
- Old-style import syntax: `(import [module [sym]])`

### Style rules (`--style` flag)
- camelCase function names → kebab-case
- Missing docstrings on `defn`/`defmacro`
- Trailing commas in parameter lists
- Earmuff variables (`*var*`)

### Design
- Handles decorated and `:async` defn layouts
- Skips quasiquote template bodies (no false positives on macros)
- Catches `LexException`, `HySyntaxError`, `HyCompileError` gracefully
- Shared utilities (`issue`, `defn-layout`) in `beautifhy.core`
- Multimethod dispatch on `Expression`/`Object` (avoids `Symbol`/`str` ambiguity)

### CLI
```
hylint [--style] [--error-only] files...
```

### Testing
- 29 tests (20 lint + 9 style)
- Tested against beautifhy, hyjinx, chasm, chasm_engine, and 3 agalmic repos (~100 .hy files) with zero false positives